### PR TITLE
fix chart overflow issue

### DIFF
--- a/components/cusipDetails.js
+++ b/components/cusipDetails.js
@@ -94,19 +94,19 @@ export default function CusipDetails({
                     })
                 }
 
-                setCpiChartData(
-                    cpiEntries
-                        .map((entry) => {
-                            return {
-                                indexDate: new Date(entry.indexDate).toLocaleDateString(),
-                                dailyIndex: Number(entry.dailyIndex),
-                                dailyAdjustedPrincipal: Number(
-                                    faceValue * entry.dailyIndex,
-                                ).toFixed(2),
-                            }
-                        })
-                        .reverse(),
-                )
+                const chartData = cpiEntries
+                    .map((entry) => {
+                        return {
+                            indexDate: new Date(entry.indexDate).toLocaleDateString(),
+                            dailyIndex: Number(entry.dailyIndex),
+                            dailyAdjustedPrincipal: Number(
+                                (faceValue * entry.dailyIndex).toFixed(2),
+                            ),
+                        }
+                    })
+                    .reverse()
+
+                setCpiChartData(chartData)
             } catch (err) {
                 setError(err.message)
                 setCpiEntries(null)
@@ -332,7 +332,14 @@ export default function CusipDetails({
                                 return `${month}/${year}`
                             }}
                         />
-                        <YAxis type="number" tickFormatter={(value) => `$${value}`} />
+                        <YAxis
+                            type="number"
+                            domain={[
+                                (dataMin) => Math.floor(dataMin * 0.95),
+                                (dataMax) => Math.ceil(dataMax * 1.05),
+                            ]}
+                            tickFormatter={(value) => `$${value}`}
+                        />
                         <Tooltip formatter={(value) => [`$${value}`, 'Daily Adjusted Principal']} />
                         <ReferenceLine
                             x={new Date().toLocaleDateString()}

--- a/styles/CusipDetails.module.css
+++ b/styles/CusipDetails.module.css
@@ -31,7 +31,7 @@
     align-items: center;
     gap: 1rem;
     flex-wrap: nowrap;
-    overflow-x: auto;
+    overflow-x: hidden;
     flex: 1;
 }
 


### PR DESCRIPTION
- call `toFixed()` and then `Number()` instead of `Number()` and then `toFixed()` since `toFixed()` returns a string, and the chart does better with numbers
- set the domain of the y-axis to the bounds of the data instead of always starting at 0
- also remove a horizontal scroll from the collapsed card

Before:

<img width="770" height="718" alt="image" src="https://github.com/user-attachments/assets/92d0488c-5ce8-43a2-a900-bfe0d3b3bb63" />



After:

<img width="765" height="721" alt="image" src="https://github.com/user-attachments/assets/3ab55e36-3852-4baa-baf0-9b667302d556" />
